### PR TITLE
fix: mutex group transformation to logic

### DIFF
--- a/flamapy/metamodels/bdd_metamodel/models/utils/pl_model.py
+++ b/flamapy/metamodels/bdd_metamodel/models/utils/pl_model.py
@@ -89,21 +89,20 @@ class PLModel():
         return f" {and_str} ".join(f"({f})" for f in formula)
 
     def _get_mutex_formula(self, relation: Relation) -> str:
-        formula = []
-        parent = relation.parent.name
-        children = {child.name for child in relation.children}
         equiv_str = self.logic_connectives['EQUIVALENCE']
         and_str = self.logic_connectives['AND']
         not_str = self.logic_connectives['NOT']
         or_str = self.logic_connectives['OR']
+        parent = relation.parent.name
+        children = {child.name for child in relation.children}
+
+        one_child_formula = []
         for child in children:
-            children_negatives = children - {child}
-            neg_children = f" {and_str} ".join(not_str + cn for cn in children_negatives)
-            formula.append(f"{child} {equiv_str} ({neg_children} {and_str} {parent})")
-        formula_str = f" {and_str} ".join(f"({f})" for f in formula)
-        children_or = f" {or_str} ".join(child for child in children)
-        left = f"({parent} {equiv_str} {not_str} ({children_or}))"
-        return f"{left} {or_str} ({formula_str})"
+            other_children_or = f" {or_str} ".join(c for c in children - {child})
+            one_child_formula.append(f"({not_str} {child} {equiv_str} ({other_children_or}))")
+        one_child_str = f" {and_str} ".join(f for f in one_child_formula)
+        no_child_str = f" {and_str} ".join(f"{not_str} {c}" for c in children)
+        return f"({no_child_str}) {or_str} (({one_child_str}) {and_str} {parent})"
 
     def _get_cardinality_formula(self, relation: Relation) -> str:
         parent = relation.parent.name

--- a/resources/models/uvl_models/mutex.uvl
+++ b/resources/models/uvl_models/mutex.uvl
@@ -1,0 +1,9 @@
+features
+	root
+		optional
+			parent
+				[0..1]
+					a
+					b
+					c
+					d

--- a/tests/test_bdd_metamodel.py
+++ b/tests/test_bdd_metamodel.py
@@ -70,6 +70,7 @@ def test_bdd_satisfiable(path: str, expected: bool):
         ("resources/models/uvl_models/Pizzas_complex.uvl", 25),
         ("resources/models/uvl_models/Truck.uvl", 234),
         ("resources/models/uvl_models/group_cardinalities.uvl", 16),
+        ("resources/models/uvl_models/mutex.uvl", 6)
         # ('resources/models/uvl_models/Trimesh_NFM.uvl', 734720),
     ],
 )


### PR DESCRIPTION
* Added mutex.uvl, a model including a mutex group, to the resources.
* Added mutex.uvl to test_bdd_metamodel.py
* Fixed _get_mutex_formula in pl_model.py so that the transformation to logic is sound.

The transformation creates two sub formulas, the first for exactly one selected child, the second for no selected children. The final formula states that either of the sub formulas must be true, and that the parent must be selected for one child to be selected.